### PR TITLE
Support Function Scope Imports

### DIFF
--- a/flyable/parse/parser_visitor.py
+++ b/flyable/parse/parser_visitor.py
@@ -207,13 +207,8 @@ class ParserVisitor(NodeVisitor, Generic[AstSubclass]):
         left_type, left_value = self.__visit_node(node.left)
         self.__reset_last()
         right_type, right_value = self.__visit_node(node.right)
-        self.__visit_node(node.op)
-
-        if isinstance(node.left.value, str) and isinstance(node.right.value, str):
-            self.__last_type = right_type
-            self.__last_value = runtime.unicode_concat(self.get_code_gen(), self.get_builder(), left_value, right_value)
-        else:    
-            self.__last_type, self.__last_value = op_call.bin_op(self, node.op, left_type, left_value, right_type,
+        self.__visit_node(node.op)   
+        self.__last_type, self.__last_value = op_call.bin_op(self, node.op, left_type, left_value, right_type,
                                                              right_value)
         ref_counter.ref_decr_incr(self, left_type, left_value)
         ref_counter.ref_decr_incr(self, right_type, right_value)

--- a/flyable/parse/variable.py
+++ b/flyable/parse/variable.py
@@ -21,6 +21,20 @@ class Variable:
         self.__is_arg: bool = False
         self.__global: bool = False
         self.__context: Context | None = None
+        self.__is_module = False
+        self.__belongs_to_module = False
+
+    def belongs_to_module(self):
+        return self.__belongs_to_module
+
+    def set_belongs_to_module(self, belongs_to_module):
+        self.__belongs_to_module = belongs_to_module
+
+    def is_module(self):
+        return self.__is_module
+
+    def set_is_module(self, is_module):
+        self.__is_module = is_module
 
     def get_id(self):
         return self.__id


### PR DESCRIPTION
Star (*) imports in functions not supported by CPython. 
Tested with a couple variations local import variations: 

```python
def print_dirname():
    from os.path import dirname
    print(dirname)

def print_sympy():
    from sympy import Symbol
    print(Symbol('x'))

def print_path():
    from os import path
    print(path)

def print_import_path():
    import os
    print(os)
    print(os.path)

print_dirname()
print_sympy()
print_path()

print_import_path()

def print_import_path():
    import os.path
    print(os)
    print(os.path)

print_import_path()
```