### PR TITLE
Qualname

### DIFF
--- a/flyable/parse/parser.py
+++ b/flyable/parse/parser.py
@@ -26,11 +26,11 @@ class Parser(ErrorThrower):
             """
             Internal class used to look at the ast get get functions
             """
-
             def __init__(self, parser):
                 self.__parser = parser
-
+                
             def visit_FunctionDef(self, node: FunctionDef) -> Any:
+                node.qualname = f"{file.get_path().replace('/', '.')[1:]}.{node.name}"
                 new_func = lang_func.LangFunc(node)
                 new_func.set_file(file)
                 file.add_func(new_func)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.13.4)
+project(CodeGen)
+
+find_package(PythonLibs REQUIRED)
+
+add_library(
+    runtime STATIC src/flyable.h src/module.h src/flyable.c 
+src/module.c)
+
+
+include_directories(${PYTHON_INCLUDE_DIRS})
+target_link_libraries(runtime ${PYTHON_LIBRARIES})

--- a/runtime/src/flyable.c
+++ b/runtime/src/flyable.c
@@ -1,7 +1,7 @@
 #include "flyable.h"
 #include "internal/pycore_frame.h"
 
-extern PyObject* _PyEval_EvalFrameDefault(PyThreadState* ts, PyFrameObject* f, int throwflag);
+extern PyObject* _PyEval_EvalFrameDefault(PyThreadState* ts, _PyInterpreterFrame* f, int throwflag);
 
 FlyableImpl* FlyableImpls = NULL;
 int FlyableImplsCount = 0;


### PR DESCRIPTION
Yeah, so for this one I just added a qualname attribute to the node so we can switch out the 

```python
return node.name
```

in `get_qualified_name` with when we're ready.
```python
return node.qualname
```

Since it's only top-level functions, I don't think we need more distinction than just the file name, I thought we were doing nested functions initially 